### PR TITLE
Add a scene per transition. Add display name option for playlists. Fix bug with streamer live detection.

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -6,6 +6,7 @@
   "yt_dlp_verbose": false,
   "notify_video_transitions": true,
   "ignore_streamer": false,
+  "eventsub_authoritative": true,
   "yt_dlp_use_cookies": false,
   "yt_dlp_browser_for_cookies": "firefox"
 }

--- a/controllers/automation_controller.py
+++ b/controllers/automation_controller.py
@@ -1571,6 +1571,13 @@ class AutomationController:
         any_definitive = False  # At least one platform gave a real answer
         eventsub_authoritative = False  # EventSub provided the answer
 
+        # When enabled, EventSub is the sole authority — Kick polls are
+        # skipped entirely.  Useful when the Twitch target and Kick target
+        # are the same streamer (Kick's stale "live" window lags behind).
+        eventsub_authoritative_setting = self.config_manager.get_settings().get(
+            "eventsub_authoritative", False
+        )
+
         if target_twitch:
             eventsub_connected = (
                 self._eventsub_listener is not None
@@ -1580,7 +1587,8 @@ class AutomationController:
                 # Primary: EventSub real-time state (always available, no HTTP)
                 is_live = self._eventsub_is_live
                 any_definitive = True
-                eventsub_authoritative = True
+                if eventsub_authoritative_setting:
+                    eventsub_authoritative = True
             elif self.twitch_live_checker and (not skip_twitch_poll or (eventsub_connected and self._eventsub_is_live is None)):
                 # Fallback: HTTP poll.  Also force a poll when EventSub is
                 # connected but _eventsub_is_live is still None — this seeds

--- a/controllers/automation_controller.py
+++ b/controllers/automation_controller.py
@@ -1949,7 +1949,11 @@ class AutomationController:
                 kick_due = (loop_count % kick_interval == 0) or force_check or ignore_streamer_changed
                 twitch_http_due = (loop_count % twitch_http_interval == 0) or force_check or ignore_streamer_changed
 
-                if kick_due or twitch_http_due:
+                # When EventSub is active with a definitive state, check
+                # every tick (just reads a boolean — no HTTP).  This makes
+                # pause/unpause near-instant instead of waiting up to 30s.
+                eventsub_has_state = eventsub_active and self._eventsub_is_live is not None
+                if kick_due or twitch_http_due or eventsub_has_state or self._raid_detected:
                     await self._check_live_status(
                         ignore_streamer,
                         skip_twitch_poll=not twitch_http_due,

--- a/controllers/automation_controller.py
+++ b/controllers/automation_controller.py
@@ -1558,15 +1558,18 @@ class AutomationController:
                 logger.warning(f"Failed to refresh Kick app token: {e}")
 
         # ── Determine live status ──
-        # EventSub is the primary source for Twitch (near-instant);
+        # EventSub is the PRIMARY source for Twitch (near-instant push).
+        # When EventSub gives a definitive answer, trust it immediately —
+        # don't let a slower Kick poll override it.
         # HTTP poll is the fallback when EventSub isn't connected.
-        # Kick always uses HTTP poll (no EventSub equivalent).
+        # Kick is only checked when EventSub is unavailable.
         #
         # Checkers return True/False/None.  None means the API call
         # failed — treat as "unknown" and keep the current state so
         # transient errors don't bounce between pause and stream.
         is_live = False
         any_definitive = False  # At least one platform gave a real answer
+        eventsub_authoritative = False  # EventSub provided the answer
 
         if target_twitch:
             eventsub_connected = (
@@ -1577,6 +1580,7 @@ class AutomationController:
                 # Primary: EventSub real-time state (always available, no HTTP)
                 is_live = self._eventsub_is_live
                 any_definitive = True
+                eventsub_authoritative = True
             elif self.twitch_live_checker and (not skip_twitch_poll or (eventsub_connected and self._eventsub_is_live is None)):
                 # Fallback: HTTP poll.  Also force a poll when EventSub is
                 # connected but _eventsub_is_live is still None — this seeds
@@ -1595,7 +1599,11 @@ class AutomationController:
                         self._eventsub_is_live = twitch_result
                         logger.info(f"Seeded _eventsub_is_live = {twitch_result} from HTTP poll (stream was already {'live' if twitch_result else 'offline'})")
 
-        if not is_live and target_kick and self.kick_live_checker:
+        # Only check Kick when EventSub didn't provide an authoritative answer.
+        # EventSub is near-instant; Kick polls lag behind and would override
+        # the real-time signal (e.g. staying paused after EventSub says offline
+        # because Kick still reports live for another ~90s).
+        if not eventsub_authoritative and not is_live and target_kick and self.kick_live_checker:
             kick_result = await asyncio.to_thread(self.kick_live_checker.is_stream_live, target_kick)
             if kick_result is None:
                 logger.debug("Kick live check returned None (API error) — skipping Kick this tick")

--- a/controllers/automation_controller.py
+++ b/controllers/automation_controller.py
@@ -871,7 +871,8 @@ class AutomationController:
             self.playback_monitor = PlaybackMonitor(
                 self.db, self.obs_controller, VLC_SOURCE_NAME,
                 event_queue=self.obs_connection.media_event_queue,
-                config=self.config_manager, scene_stream=SCENE_STREAM
+                config=self.config_manager, scene_stream=SCENE_STREAM,
+                scene_rotation_screen=SCENE_ROTATION_SCREEN,
             )
         else:
             # Update reference after OBS reconnect (new OBSController instance)

--- a/controllers/automation_controller.py
+++ b/controllers/automation_controller.py
@@ -1513,7 +1513,14 @@ class AutomationController:
             return
 
         # Refresh tokens in background threads (each can block up to 10s)
-        if target_twitch and self.twitch_live_checker and not skip_twitch_poll:
+        # Also refresh Twitch token when EventSub seeding is needed, even
+        # if the regular Twitch poll is skipped this tick.
+        need_twitch_token = not skip_twitch_poll or (
+            self._eventsub_listener is not None
+            and self._eventsub_listener.is_connected
+            and self._eventsub_is_live is None
+        )
+        if target_twitch and self.twitch_live_checker and need_twitch_token:
             try:
                 await asyncio.to_thread(self.twitch_live_checker.refresh_token_if_needed)
             except Exception as e:
@@ -1529,7 +1536,12 @@ class AutomationController:
         # EventSub is the primary source for Twitch (near-instant);
         # HTTP poll is the fallback when EventSub isn't connected.
         # Kick always uses HTTP poll (no EventSub equivalent).
+        #
+        # Checkers return True/False/None.  None means the API call
+        # failed — treat as "unknown" and keep the current state so
+        # transient errors don't bounce between pause and stream.
         is_live = False
+        any_definitive = False  # At least one platform gave a real answer
 
         if target_twitch:
             eventsub_connected = (
@@ -1539,14 +1551,37 @@ class AutomationController:
             if eventsub_connected and self._eventsub_is_live is not None:
                 # Primary: EventSub real-time state (always available, no HTTP)
                 is_live = self._eventsub_is_live
-            elif self.twitch_live_checker and not skip_twitch_poll:
-                # Fallback: HTTP poll (EventSub not connected yet, or no data)
-                is_live = await asyncio.to_thread(
+                any_definitive = True
+            elif self.twitch_live_checker and (not skip_twitch_poll or (eventsub_connected and self._eventsub_is_live is None)):
+                # Fallback: HTTP poll.  Also force a poll when EventSub is
+                # connected but _eventsub_is_live is still None — this seeds
+                # the live state for streams that were already live before OSR
+                # started (no stream.online event will ever fire for them).
+                twitch_result = await asyncio.to_thread(
                     self.twitch_live_checker.is_stream_live, target_twitch,
                 )
+                if twitch_result is None:
+                    logger.debug("Twitch live check returned None (API error) — skipping Twitch this tick")
+                else:
+                    is_live = twitch_result
+                    any_definitive = True
+                    # Seed EventSub state so future ticks use the real-time path
+                    if eventsub_connected and self._eventsub_is_live is None:
+                        self._eventsub_is_live = twitch_result
+                        logger.info(f"Seeded _eventsub_is_live = {twitch_result} from HTTP poll (stream was already {'live' if twitch_result else 'offline'})")
 
         if not is_live and target_kick and self.kick_live_checker:
-            is_live = await asyncio.to_thread(self.kick_live_checker.is_stream_live, target_kick)
+            kick_result = await asyncio.to_thread(self.kick_live_checker.is_stream_live, target_kick)
+            if kick_result is None:
+                logger.debug("Kick live check returned None (API error) — skipping Kick this tick")
+            else:
+                is_live = kick_result
+                any_definitive = True
+
+        # If ALL platforms errored, bail out — keep current state
+        if not any_definitive and (target_twitch or target_kick):
+            logger.debug("All live checks returned None (API errors) — keeping current state")
+            return
 
         if ignore_streamer:
             is_live = False
@@ -1678,6 +1713,10 @@ class AutomationController:
             self.last_stream_status = "offline"
             self._rotation_postpone_logged = False
             self.notification_service.notify_streamer_offline()
+            # Update category for current video after unpause — during the
+            # pause period the category may have drifted (e.g., the pause
+            # happened right after a transition without a category update).
+            await self._update_category_for_current_video()
 
     def _tick_save_playback(self) -> None:
         """Save playback position every tick and apply deferred seek if pending."""

--- a/controllers/automation_controller.py
+++ b/controllers/automation_controller.py
@@ -33,6 +33,7 @@ from handlers.content_switch_handler import ContentSwitchHandler
 from handlers.dashboard_handler import DashboardHandler
 from handlers.temp_playback_handler import TempPlaybackHandler
 from utils.video_processor import kill_all_running_processes as kill_processor_processes
+from utils.video_utils import strip_ordering_prefix
 from services.web_dashboard_client import WebDashboardClient
 from monitors.obs_freeze_monitor import OBSFreezeMonitor
 from config.constants import (
@@ -695,8 +696,32 @@ class AutomationController:
                 pause_image=DEFAULT_PAUSE_IMAGE,
                 rotation_image=DEFAULT_ROTATION_IMAGE,
             )
-            # Repopulate VLC source playlist from the live folder
-            self.obs_controller.update_vlc_source(VLC_SOURCE_NAME, self.config_manager.video_folder)
+            # Repopulate VLC source playlist from the live folder.
+            # If we have a pending seek target, rotate the playlist so VLC
+            # starts on that video (OBS VLC source always begins at index 0).
+            rotated_playlist = None
+            resume_file = None
+            if self._pending_seek_video:
+                folder = str(self.config_manager.video_folder)
+                all_files = sorted(
+                    f for f in os.listdir(folder)
+                    if f.lower().endswith(VIDEO_EXTENSIONS)
+                )
+                for i, f in enumerate(all_files):
+                    if strip_ordering_prefix(f) == self._pending_seek_video:
+                        rotated_playlist = all_files[i:] + all_files[:i]
+                        resume_file = all_files[i]
+                        break
+
+            self.obs_controller.update_vlc_source(
+                VLC_SOURCE_NAME,
+                self.config_manager.video_folder,
+                playlist=rotated_playlist,
+            )
+            # Override playback monitor so it tracks the correct video
+            if resume_file and self.playback_monitor:
+                self.playback_monitor._current_video = resume_file
+                logger.info(f"OBS freeze recovery: rotated playlist to start at {resume_file}")
             logger.info("OBS freeze recovery: scenes and VLC source restored")
 
         # 7. Switch to the stream scene so OBS shows the right content

--- a/handlers/dashboard_handler.py
+++ b/handlers/dashboard_handler.py
@@ -583,6 +583,16 @@ class DashboardHandler:
 
         # Switch to stream scene
         if ctrl.obs_controller:
+            # Drain stale events and arm suppression BEFORE the scene switch.
+            # Switching to OSR Stream makes VLC visible, which fires a
+            # MediaInputPlaybackStarted event.  Without suppression the
+            # playback monitor would treat it as a real transition —
+            # deleting the current video and advancing to the next one.
+            if ctrl.playback_monitor:
+                ctrl.playback_monitor._drain_queue()
+                ctrl.playback_monitor._vlc_update_suppress = True
+                ctrl.playback_monitor._arm_suppress()
+
             ctrl.obs_controller.switch_scene(self._scene_stream)
 
         # Restore playback position

--- a/handlers/dashboard_handler.py
+++ b/handlers/dashboard_handler.py
@@ -153,6 +153,7 @@ class DashboardHandler:
             for key in (
                 "stream_title_template",
                 "ignore_streamer",
+                "eventsub_authoritative",
                 "notify_video_transitions",
                 "min_playlists_per_rotation",
                 "max_playlists_per_rotation",
@@ -460,6 +461,7 @@ class DashboardHandler:
         allowed_keys = {
             "stream_title_template",
             "ignore_streamer",
+            "eventsub_authoritative",
             "notify_video_transitions",
             "min_playlists_per_rotation",
             "max_playlists_per_rotation",

--- a/handlers/dashboard_handler.py
+++ b/handlers/dashboard_handler.py
@@ -14,6 +14,7 @@ from typing import Optional, TYPE_CHECKING
 from dotenv import set_key
 from config.constants import (
     DEFAULT_VIDEO_FOLDER,
+    VIDEO_EXTENSIONS,
 )
 
 if TYPE_CHECKING:
@@ -188,6 +189,18 @@ class DashboardHandler:
         # Download status
         download_active = ctrl.download_manager.background_download_in_progress if ctrl.download_manager else False
 
+        # Pending (next rotation) video files
+        pending_videos: list[str] = []
+        try:
+            pending_folder = ctrl.config_manager.next_rotation_folder
+            if pending_folder and os.path.isdir(pending_folder):
+                pending_videos = sorted(
+                    f for f in os.listdir(pending_folder)
+                    if f.lower().endswith(VIDEO_EXTENSIONS)
+                )
+        except Exception:
+            pass
+
         # Guard flags — determine whether skip/rotation are safe right now
         videos_remaining = len(queue) - (queue.index(ctrl.playback_monitor._current_video) + 1) if (
             ctrl.playback_monitor and ctrl.playback_monitor._current_video in queue
@@ -217,6 +230,7 @@ class DashboardHandler:
             "queue": queue,
             "connections": connections,
             "download_active": download_active,
+            "pending_videos": pending_videos,
             "can_skip": can_skip,
             "skip_ready": self._skip_ready,
             "can_trigger_rotation": can_trigger_rotation,

--- a/handlers/dashboard_handler.py
+++ b/handlers/dashboard_handler.py
@@ -128,7 +128,7 @@ class DashboardHandler:
             for p in ctrl.config_manager.get_playlists():
                 name = p.get("name", "")
                 stats = db_stats.get(name, {})
-                playlists.append({
+                entry: dict = {
                     "name": name,
                     "url": p.get("url", ""),
                     "twitch_category": p.get("twitch_category", "") or p.get("category", ""),
@@ -137,7 +137,10 @@ class DashboardHandler:
                     "priority": p.get("priority", 1),
                     "last_played": stats.get("last_played"),
                     "play_count": stats.get("play_count", 0),
-                })
+                }
+                if p.get("display_name"):
+                    entry["display_name"] = p["display_name"]
+                playlists.append(entry)
         except Exception:
             pass
 
@@ -815,6 +818,7 @@ class DashboardHandler:
             "kick_category": payload.get("kick_category", ""),
             "enabled": payload.get("enabled", True),
             "priority": payload.get("priority", 1),
+            **(({"display_name": payload["display_name"]}) if payload.get("display_name") else {}),
         })
         self._save_playlists_raw(data)
 
@@ -837,6 +841,11 @@ class DashboardHandler:
                     p["enabled"] = payload["enabled"]
                 if "priority" in payload:
                     p["priority"] = payload["priority"]
+                if "display_name" in payload:
+                    if payload["display_name"]:
+                        p["display_name"] = payload["display_name"]
+                    else:
+                        p.pop("display_name", None)
                 self._save_playlists_raw(data)
                 return
         logger.warning(f"Playlist '{name}' not found for update")

--- a/integrations/platforms/kick.py
+++ b/integrations/platforms/kick.py
@@ -150,13 +150,19 @@ class KickUpdater(StreamPlatform):
 
                     logger.info(f"[{self.platform_name}] SUCCESS! Tokens exchanged and saved.")
 
-                    # Auto-resolve channel_id if it wasn't set
-                    if not self.channel_id and "channel_id" in token_data:
-                        self.channel_id = str(token_data["channel_id"])
+                    # Always adopt the channel_id from the freshly authorized account.
+                    # This ensures that if the user re-auths as a different account,
+                    # we use the new account's tokens (not stale ones from a prior auth).
+                    if "channel_id" in token_data:
+                        new_channel_id = str(token_data["channel_id"])
+                        if self.channel_id and self.channel_id != new_channel_id:
+                            logger.warning(
+                                f"[{self.platform_name}] Channel ID changed: "
+                                f"{self.channel_id} → {new_channel_id} "
+                                "(authorized as a different account)"
+                            )
+                        self.channel_id = new_channel_id
                         self._persist_channel_id(self.channel_id)
-                        logger.info(
-                            f"[{self.platform_name}] Channel ID auto-resolved: {self.channel_id}"
-                        )
 
                     await self.api.start_token_refresh()
                     logger.info(f"[{self.platform_name}] Token refresh started. Authorization complete!")

--- a/managers/playlist_manager.py
+++ b/managers/playlist_manager.py
@@ -116,10 +116,28 @@ class PlaylistManager:
 
         SEPARATOR = ' | '
 
-        # Build the full list: current playlists, then preview playlists
-        all_names = [p.upper() for p in playlists] if playlists else []
+        # Build display-name lookup from config so playlists with different
+        # internal names can share the same title representation.
+        config_playlists = self.config.get_playlists()
+        display_map: dict[str, str] = {}
+        for p in config_playlists:
+            name = p.get('name', '')
+            display_map[name] = p.get('display_name') or name
+
+        # Resolve to display names and deduplicate (preserving order)
+        seen: set[str] = set()
+        all_names: list[str] = []
+        for name in (playlists or []):
+            dn = display_map.get(name, name).upper()
+            if dn not in seen:
+                seen.add(dn)
+                all_names.append(dn)
         if preview_playlists:
-            all_names.extend(p.upper() for p in preview_playlists)
+            for name in preview_playlists:
+                dn = display_map.get(name, name).upper()
+                if dn not in seen:
+                    seen.add(dn)
+                    all_names.append(dn)
 
         if not all_names:
             return template.replace('{PLAYLISTS}', 'VARIETY')[:max_length]

--- a/managers/playlist_manager.py
+++ b/managers/playlist_manager.py
@@ -330,12 +330,19 @@ class PlaylistManager:
             logger.error(f"Error copying files: {e}")
             return False
 
+    # Regex to extract playlist name from yt-dlp filenames: PLAYLIST_NNN_Title.ext
+    _PLAYLIST_FROM_FILENAME = re.compile(r'^(.+?)_\d{3}_')
+
     def rename_videos_with_playlist_prefix(self, folder: str, playlist_order: list[str]) -> bool:
         """Rename video files with ordering prefix based on their source playlist.
         
         Files are prefixed with 'XX_' where XX is the playlist's position in the
         rotation order (01, 02, etc.). This ensures alphabetical sorting groups
         videos by playlist and plays them in the correct order.
+        
+        Falls back to extracting the playlist name from the filename pattern
+        (e.g. ``REACTS_001_Title.mp4`` → ``REACTS``) when the video is not
+        found in the database.
         
         Args:
             folder: Path to the folder containing video files to rename
@@ -353,7 +360,11 @@ class PlaylistManager:
             for i, name in enumerate(playlist_order):
                 playlist_prefix[name] = f"{i + 1:02d}"
             
+            # Case-insensitive reverse lookup for filename-based fallback
+            playlist_prefix_lower = {name.lower(): prefix for name, prefix in playlist_prefix.items()}
+            
             renamed_count = 0
+            fallback_count = 0
             for filename in os.listdir(folder):
                 if not filename.lower().endswith(VIDEO_EXTENSIONS):
                     continue
@@ -367,12 +378,26 @@ class PlaylistManager:
                 # cross-playlist registrations don't cause wrong prefixes
                 rotation_names = list(playlist_prefix.keys())
                 video = self.db.get_video_by_filename(filename, playlist_names=rotation_names)
-                if not video:
-                    logger.debug(f"Video not in database, skipping prefix: {filename}")
-                    continue
                 
-                playlist_name = video.get('playlist_name', '')
-                prefix = playlist_prefix.get(playlist_name, '99')  # Default to end
+                prefix = None
+                if video:
+                    playlist_name = video.get('playlist_name', '')
+                    prefix = playlist_prefix.get(playlist_name, '99')
+                else:
+                    # Fallback: extract playlist name from filename pattern
+                    m = self._PLAYLIST_FROM_FILENAME.match(filename)
+                    if m:
+                        extracted = m.group(1)
+                        prefix = playlist_prefix_lower.get(extracted.lower())
+                        if prefix:
+                            fallback_count += 1
+                        else:
+                            logger.debug(f"Filename prefix '{extracted}' not in rotation playlists, skipping: {filename}")
+                    else:
+                        logger.debug(f"Cannot determine playlist for: {filename}")
+                
+                if prefix is None:
+                    continue
                 
                 new_filename = f"{prefix}_{filename}"
                 src = os.path.join(folder, filename)
@@ -382,7 +407,10 @@ class PlaylistManager:
                 renamed_count += 1
             
             if renamed_count > 0:
-                logger.info(f"Renamed {renamed_count} videos with playlist prefix in {folder}")
+                msg = f"Renamed {renamed_count} videos with playlist prefix in {folder}"
+                if fallback_count:
+                    msg += f" ({fallback_count} via filename fallback)"
+                logger.info(msg)
             return True
             
         except Exception as e:

--- a/playback/playback_monitor.py
+++ b/playback/playback_monitor.py
@@ -384,11 +384,21 @@ class PlaybackMonitor:
                 vlc_ready = self._wait_for_vlc_playing()
                 if vlc_ready:
                     # Extra buffer — VLC reports PLAYING before its decode
-                    # buffer has filled. Give it a moment so the switch
+                    # buffer has filled.  Give it a moment so the switch
                     # back to stream scene shows a clean frame.
                     time.sleep(0.5)
                 logger.info(f"Scene mask: restoring '{self.scene_stream}' (VLC ready={vlc_ready})")
                 self.obs_controller.switch_scene(self.scene_stream)
+
+                # The scene switches (rotation → stream) and VLC reload
+                # generate spurious started/ended events that accumulated
+                # during the wait.  Drain them and re-arm suppression so
+                # the next check() doesn't miscount them as transitions.
+                drained = self._drain_queue()
+                self._vlc_update_suppress = True
+                self._arm_suppress()
+                if drained:
+                    logger.debug(f"Scene mask: drained {drained} spurious events after restore")
 
         return result
 

--- a/playback/playback_monitor.py
+++ b/playback/playback_monitor.py
@@ -304,6 +304,7 @@ class PlaybackMonitor:
 
                     # Mask VLC reload stutter with rotation screen
                     if not _scene_masked and self._scene_rotation_screen and self.obs_controller:
+                        logger.info(f"Scene mask: switching to '{self._scene_rotation_screen}' for VLC reload")
                         self.obs_controller.switch_scene(self._scene_rotation_screen)
                         _scene_masked = True
 
@@ -380,7 +381,13 @@ class PlaybackMonitor:
             # the automation controller owns the next scene switch in those
             # cases (rotation screen for content switch / temp playback reload).
             if _scene_masked and self.obs_controller and not self._all_content_consumed and not self._needs_vlc_refresh:
-                self._wait_for_vlc_playing()
+                vlc_ready = self._wait_for_vlc_playing()
+                if vlc_ready:
+                    # Extra buffer — VLC reports PLAYING before its decode
+                    # buffer has filled. Give it a moment so the switch
+                    # back to stream scene shows a clean frame.
+                    time.sleep(0.5)
+                logger.info(f"Scene mask: restoring '{self.scene_stream}' (VLC ready={vlc_ready})")
                 self.obs_controller.switch_scene(self.scene_stream)
 
         return result

--- a/playback/playback_monitor.py
+++ b/playback/playback_monitor.py
@@ -43,12 +43,14 @@ class PlaybackMonitor:
         event_queue: Queue,
         config: Optional['ConfigManager'] = None,
         scene_stream: str = "OSR Stream",
+        scene_rotation_screen: str = "",
     ):
         self.db = db
         self.obs_controller = obs_controller
         self.vlc_source_name = vlc_source_name
         self.config = config
         self.scene_stream = scene_stream
+        self._scene_rotation_screen = scene_rotation_screen
 
         # Thread-safe queue fed by OBSConnectionManager EventClient
         self._event_queue: Queue = event_queue
@@ -251,115 +253,135 @@ class PlaybackMonitor:
         if transition_count == 0:
             return result
 
+        # Scene masking: switch to rotation screen while VLC reloads to
+        # hide the brief playback stutter.  The finally block restores the
+        # stream scene so early returns inside the loop are safe.
+        _scene_masked = False
+
         # Process each transition sequentially (handles rapid skips)
-        for _ in range(transition_count):
-            if self._all_content_consumed:
-                break
+        try:
+            for _ in range(transition_count):
+                if self._all_content_consumed:
+                    break
 
-            previous_video = self._current_video
-            previous_original = strip_ordering_prefix(previous_video)
-            files = self._get_video_files()
-            is_last = len(files) <= 1
+                previous_video = self._current_video
+                previous_original = strip_ordering_prefix(previous_video)
+                files = self._get_video_files()
+                is_last = len(files) <= 1
 
-            if is_last:
-                # Last video finished — check temp playback refresh
-                if self._temp_playback_mode:
-                    logger.info(
-                        "Last video done in temp playback — signaling VLC refresh"
-                    )
-                    self._needs_vlc_refresh = True
+                if is_last:
+                    # Last video finished — check temp playback refresh
+                    if self._temp_playback_mode:
+                        logger.info(
+                            "Last video done in temp playback — signaling VLC refresh"
+                        )
+                        self._needs_vlc_refresh = True
+                        result['transition'] = True
+                        result['previous_video'] = previous_original
+                        result['current_video'] = None
+                        return result
+
+                    # Normal mode: delete last video, mark consumed
+                    if self._delete_on_transition:
+                        filepath = os.path.join(self.video_folder, previous_video)
+                        self._delete_video(filepath)
+
+                    self._all_content_consumed = True
+                    self._current_video = None
                     result['transition'] = True
                     result['previous_video'] = previous_original
                     result['current_video'] = None
+                    result['all_consumed'] = True
+                    logger.info(
+                        f"Final video finished: {previous_original} — "
+                        f"all content consumed"
+                    )
                     return result
 
-                # Normal mode: delete last video, mark consumed
+                # Normal mid-playlist transition
                 if self._delete_on_transition:
                     filepath = os.path.join(self.video_folder, previous_video)
-                    self._delete_video(filepath)
 
-                self._all_content_consumed = True
-                self._current_video = None
-                result['transition'] = True
-                result['previous_video'] = previous_original
-                result['current_video'] = None
-                result['all_consumed'] = True
-                logger.info(
-                    f"Final video finished: {previous_original} — "
-                    f"all content consumed"
-                )
-                return result
+                    # Mask VLC reload stutter with rotation screen
+                    if not _scene_masked and self._scene_rotation_screen and self.obs_controller:
+                        self.obs_controller.switch_scene(self._scene_rotation_screen)
+                        _scene_masked = True
 
-            # Normal mid-playlist transition
-            if self._delete_on_transition:
-                filepath = os.path.join(self.video_folder, previous_video)
-                deleted = self._delete_video(filepath)
-                if not deleted:
-                    # File still locked — skip this transition and retry
-                    # on the next tick.  Don't update VLC or advance the
-                    # pointer; VLC is still playing this file anyway.
-                    logger.warning(
-                        f"Skipping transition for {previous_video} — "
-                        f"file could not be deleted, will retry next cycle"
-                    )
-                    break
-                # Reload VLC source to keep its internal playlist in
-                # sync with the filesystem.  Without this, VLC may play
-                # ghost entries from its stale in-memory playlist —
-                # especially after dashboard skips or when the VLC plugin
-                # caches aggressively.  The reload causes a brief stutter
-                # (~0.5s) but prevents desync.
-                #
-                # In TEMP PLAYBACK mode we additionally drain stale events —
-                # VLC's static playlist doesn't include files downloaded
-                # after the source was last set, and VLC may have fired
-                # extra ended/started pairs while looping on its exhausted
-                # playlist before this tick ran.
-                self._update_vlc_source()
-                self._drain_queue()
+                    deleted = self._delete_video(filepath)
+                    if not deleted:
+                        # File still locked — skip this transition and retry
+                        # on the next tick.  Don't update VLC or advance the
+                        # pointer; VLC is still playing this file anyway.
+                        logger.warning(
+                            f"Skipping transition for {previous_video} — "
+                            f"file could not be deleted, will retry next cycle"
+                        )
+                        break
+                    # Reload VLC source to keep its internal playlist in
+                    # sync with the filesystem.  Without this, VLC may play
+                    # ghost entries from its stale in-memory playlist —
+                    # especially after dashboard skips or when the VLC plugin
+                    # caches aggressively.  The reload causes a brief stutter
+                    # (~0.5s) but prevents desync.
+                    #
+                    # In TEMP PLAYBACK mode we additionally drain stale events —
+                    # VLC's static playlist doesn't include files downloaded
+                    # after the source was last set, and VLC may have fired
+                    # extra ended/started pairs while looping on its exhausted
+                    # playlist before this tick ran.
+                    self._update_vlc_source()
+                    self._drain_queue()
 
-            # Advance to next video
-            files = self._get_video_files()
-            if self._delete_on_transition:
-                # After deletion the next file is always first
-                self._current_video = files[0] if files else None
-            else:
-                # Prepared-rotation mode — advance by index
-                cur_idx = (
-                    files.index(previous_video)
-                    if previous_video in files else -1
-                )
-                if cur_idx >= 0 and cur_idx + 1 < len(files):
-                    self._current_video = files[cur_idx + 1]
+                # Advance to next video
+                files = self._get_video_files()
+                if self._delete_on_transition:
+                    # After deletion the next file is always first
+                    self._current_video = files[0] if files else None
                 else:
-                    self._current_video = None
+                    # Prepared-rotation mode — advance by index
+                    cur_idx = (
+                        files.index(previous_video)
+                        if previous_video in files else -1
+                    )
+                    if cur_idx >= 0 and cur_idx + 1 < len(files):
+                        self._current_video = files[cur_idx + 1]
+                    else:
+                        self._current_video = None
 
-            if self._current_video:
-                current_original = strip_ordering_prefix(self._current_video)
-                logger.info(
-                    f"Video transition: {previous_original} -> {current_original}"
-                )
-                # Only populate the *last* transition into the result
-                result['transition'] = True
-                result['previous_video'] = previous_original
-                result['current_video'] = current_original
-                # After refreshing VLC in temp playback, stop processing
-                # further transitions in this tick — any remaining count
-                # from _count_transitions is from stale VLC loop events on
-                # the old (now-replaced) playlist.
-                if self._temp_playback_mode:
+                if self._current_video:
+                    current_original = strip_ordering_prefix(self._current_video)
+                    logger.info(
+                        f"Video transition: {previous_original} -> {current_original}"
+                    )
+                    # Only populate the *last* transition into the result
+                    result['transition'] = True
+                    result['previous_video'] = previous_original
+                    result['current_video'] = current_original
+                    # After refreshing VLC in temp playback, stop processing
+                    # further transitions in this tick — any remaining count
+                    # from _count_transitions is from stale VLC loop events on
+                    # the old (now-replaced) playlist.
+                    if self._temp_playback_mode:
+                        return result
+                else:
+                    self._all_content_consumed = True
+                    result['transition'] = True
+                    result['previous_video'] = previous_original
+                    result['current_video'] = None
+                    result['all_consumed'] = True
+                    logger.info(
+                        f"Final video finished: {previous_original} — "
+                        f"all content consumed"
+                    )
                     return result
-            else:
-                self._all_content_consumed = True
-                result['transition'] = True
-                result['previous_video'] = previous_original
-                result['current_video'] = None
-                result['all_consumed'] = True
-                logger.info(
-                    f"Final video finished: {previous_original} — "
-                    f"all content consumed"
-                )
-                return result
+        finally:
+            # Restore stream scene after masking VLC reload stutter.
+            # Skip when all content is consumed or VLC refresh is pending —
+            # the automation controller owns the next scene switch in those
+            # cases (rotation screen for content switch / temp playback reload).
+            if _scene_masked and self.obs_controller and not self._all_content_consumed and not self._needs_vlc_refresh:
+                self._wait_for_vlc_playing()
+                self.obs_controller.switch_scene(self.scene_stream)
 
         return result
 
@@ -534,6 +556,24 @@ class PlaybackMonitor:
                 logger.debug(f"Updated VLC source: {len(files)} videos remaining")
         except Exception as e:
             logger.error(f"Failed to update VLC source after deletion: {e}")
+
+    def _wait_for_vlc_playing(self, timeout: float = 3.0) -> bool:
+        """Poll VLC source until it reports PLAYING, or timeout.
+
+        Used after a VLC source reload while the rotation screen is
+        displayed — once VLC is playing we can safely switch back to
+        the stream scene without the viewer seeing a stutter.
+        """
+        if not self.obs_controller:
+            return False
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            status = self.obs_controller.get_media_input_status(self.vlc_source_name)
+            if status and status.get('media_state') == 'OBS_MEDIA_STATE_PLAYING':
+                return True
+            time.sleep(0.1)
+        logger.debug("Timed out waiting for VLC to start playing after reload")
+        return False
 
     # ------------------------------------------------------------------
     # Category resolution

--- a/services/kick_live_checker.py
+++ b/services/kick_live_checker.py
@@ -74,7 +74,7 @@ class KickLiveChecker:
             logger.error(f"Failed to refresh Kick token: {e}")
             return False
 
-    def is_stream_live(self, channel_slug: str) -> bool:
+    def is_stream_live(self, channel_slug: str) -> Optional[bool]:
         """
         Check if a Kick channel is live via the public channels API.
 
@@ -82,11 +82,11 @@ class KickLiveChecker:
             channel_slug: Kick channel slug (e.g. 'xqc')
 
         Returns:
-            True if channel is live, False otherwise
+            True if channel is live, False if offline, None on API error
         """
         if not self.token:
             logger.debug("No Kick token available for live check")
-            return False
+            return None
 
         headers = {"Authorization": f"Bearer {self.token}"}
         params = {"slug": [channel_slug]}
@@ -104,7 +104,7 @@ class KickLiveChecker:
                 logger.debug(f"Checked Kick {channel_slug} live status: {is_live}")
                 return is_live
             logger.debug(f"Kick channel '{channel_slug}' not found in API response")
-            return False
+            return None
         except requests.RequestException as e:
             logger.error(f"Failed to check Kick stream status for {channel_slug}: {e}")
-            return False
+            return None

--- a/services/twitch_live_checker.py
+++ b/services/twitch_live_checker.py
@@ -6,7 +6,7 @@ checks whether specified channels are currently streaming.
 import requests
 import time
 import logging
-from typing import Tuple
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ class TwitchLiveChecker:
             logger.error(f"Failed to get broadcaster ID: {e}")
             return ""
 
-    def is_stream_live(self, username: str) -> bool:
+    def is_stream_live(self, username: str) -> Optional[bool]:
         """
         Check if a Twitch user is live.
         
@@ -112,11 +112,11 @@ class TwitchLiveChecker:
             username: Twitch username to check
         
         Returns:
-            True if user is live, False otherwise
+            True if user is live, False if offline, None on API error
         """
         if not self.token:
             logger.debug("No Twitch token available for live check")
-            return False
+            return None
         
         headers = {
             "Client-ID": self.client_id,
@@ -133,4 +133,4 @@ class TwitchLiveChecker:
             return is_live
         except requests.RequestException as e:
             logger.error(f"Failed to check stream status for {username}: {e}")
-            return False
+            return None

--- a/utils/video_utils.py
+++ b/utils/video_utils.py
@@ -21,6 +21,13 @@ logger = logging.getLogger(__name__)
 # Prefix pattern: "XX_" where XX is a 2-digit number
 PREFIX_PATTERN = re.compile(r'^\d{2}_')
 
+# Pattern to extract playlist name from video filename
+# e.g., "BALL x PIT_001_This Game Changed My Life.mp4" → "BALL x PIT"
+_PLAYLIST_FROM_FILENAME = re.compile(r'^(.+?)_\d{3}_')
+
+# Cache of filenames already logged as missing from DB to avoid spam
+_db_miss_logged: set[str] = set()
+
 
 def strip_ordering_prefix(filename: str) -> str:
     """Strip the ordering prefix (e.g., '01_') from a video filename.
@@ -122,22 +129,29 @@ def resolve_category_for_video(
 
         # Look up the video in database to find its source playlist
         video = db.get_video_by_filename(clean_filename)
-        if not video:
-            logger.debug(f"Video not found in database: {clean_filename}")
-            return None
+        playlist_name = video.get('playlist_name') if video else None
 
-        playlist_name = video.get('playlist_name')
+        # Fallback: extract playlist name from filename convention
+        # e.g., "IRL_001_Going to Taco Bell..." → "IRL"
         if not playlist_name:
-            logger.debug(f"No playlist_name for video: {video_filename}")
-            return None
+            m = _PLAYLIST_FROM_FILENAME.match(clean_filename)
+            if m:
+                playlist_name = m.group(1)
+            if not playlist_name:
+                if clean_filename not in _db_miss_logged:
+                    _db_miss_logged.add(clean_filename)
+                    logger.debug(f"Cannot determine playlist for video: {clean_filename}")
+                return None
 
         # Get the category for this playlist from playlists config
         playlists_config = config.get_playlists()
         for p in playlists_config:
-            if p.get('name') == playlist_name:
+            if p.get('name', '').upper() == playlist_name.upper():
                 return resolve_playlist_categories(p)
 
-        logger.debug(f"Playlist '{playlist_name}' no longer in config (may have been removed) — skipping category update for: {video_filename}")
+        if clean_filename not in _db_miss_logged:
+            _db_miss_logged.add(clean_filename)
+            logger.debug(f"Playlist '{playlist_name}' not in config — skipping category update for: {video_filename}")
         return None
     except Exception as e:
         logger.error(f"Error getting category for video {video_filename}: {e}")


### PR DESCRIPTION
Also adds a configuration option on whether to use EventSub as the main and sole authority for checking live statuses.  
  
Fixes an issue with freeze recovery recovering to normal content when occurring while in fallback mode.  
Update KICK_CHANNEL_ID even if it already exists. This allows the user to switch accounts without trouble.